### PR TITLE
Expose size sort in finder controls

### DIFF
--- a/common/types.ts
+++ b/common/types.ts
@@ -1,4 +1,4 @@
-export type SortOption = "name" | "date";
+export type SortOption = "name" | "date" | "size";
 export type FileItem = {
   name: string;
   isDirectory: boolean;

--- a/frontend/finder/Controls.tsx
+++ b/frontend/finder/Controls.tsx
@@ -44,6 +44,7 @@ export default function Controls() {
       >
         <option value="name">名前順</option>
         <option value="date">更新日時順</option>
+        <option value="size">サイズ順</option>
       </select>
       <button
         onClick={() => setDarkMode(!darkMode)}


### PR DESCRIPTION
## Summary

- add size to the shared SortOption type
- expose the existing API size sort in the finder sort selector

Closes #10

## Tests

- bun test
- bunx tsc --noEmit