### PR TITLE
Cache transformed image buffers in memory

### DIFF
--- a/backend/app.test.ts
+++ b/backend/app.test.ts
@@ -1,11 +1,13 @@
 import { afterAll, beforeAll, expect, test } from "bun:test";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, rm, stat, utimes, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import sharp from "sharp";
 
 let app: { fetch: (request: Request) => Response | Promise<Response> };
+let createTransformedImageCacheKey: typeof import("./app.ts").createTransformedImageCacheKey;
 let tempDir: string;
+let cacheAlternatePng: Buffer;
 const originalArgv = [...process.argv];
 
 function crc32(buffer: Buffer) {
@@ -54,6 +56,17 @@ function insertPngChunkBeforeIend(png: Buffer, chunk: Buffer) {
   throw new Error("IEND chunk not found");
 }
 
+function createSolidPng(background: { r: number; g: number; b: number }) {
+  return sharp({
+    create: {
+      width: 4,
+      height: 4,
+      channels: 3,
+      background,
+    },
+  }).png({ compressionLevel: 0 }).toBuffer();
+}
+
 beforeAll(async () => {
   tempDir = await mkdtemp(join(tmpdir(), "imgserver-"));
   await sharp({
@@ -80,9 +93,13 @@ beforeAll(async () => {
       createPngTextChunk("Comment", commentText),
     ),
   );
+  const cacheOriginalPng = await createSolidPng({ r: 200, g: 40, b: 40 });
+  cacheAlternatePng = await createSolidPng({ r: 40, g: 200, b: 40 });
+  expect(cacheAlternatePng.byteLength).toBe(cacheOriginalPng.byteLength);
+  await writeFile(join(tempDir, "cache.png"), cacheOriginalPng);
 
   process.argv = ["bun", "test", "--dir", tempDir, "--showMetadata"];
-  ({ default: app } = await import("./app.ts"));
+  ({ default: app, createTransformedImageCacheKey } = await import("./app.ts"));
 });
 
 afterAll(async () => {
@@ -151,4 +168,72 @@ test("returns truncated PNG text metadata", async () => {
   });
   expect(metadata.textEntries[0].value).toStartWith("PNG comment PNG comment");
   expect(metadata.textEntries[0].value.length).toBe(16 * 1024);
+});
+
+test("reuses cached transformed image buffers for unchanged source identity", async () => {
+  const imagePath = join(tempDir, "cache.png");
+  const originalInfo = await stat(imagePath);
+  const requestUrl = "http://localhost/.be/images/cache.png?width=2&height=2&format=webp";
+
+  const firstResponse = await app.fetch(new Request(requestUrl));
+  expect(firstResponse.status).toBe(200);
+  const firstBuffer = Buffer.from(await firstResponse.arrayBuffer());
+
+  await writeFile(imagePath, cacheAlternatePng);
+  await utimes(imagePath, originalInfo.atime, originalInfo.mtime);
+
+  const secondResponse = await app.fetch(new Request(requestUrl));
+  expect(secondResponse.status).toBe(200);
+  const secondBuffer = Buffer.from(await secondResponse.arrayBuffer());
+
+  expect(secondBuffer.equals(firstBuffer)).toBe(true);
+});
+
+test("builds transformed image cache keys from source identity and transform options", () => {
+  const commonOptions = {
+    mtime: 123,
+    size: 456,
+    width: "100",
+    height: "80",
+    fit: "inside",
+    format: "webp",
+    keepMetadata: false,
+  };
+
+  const regularKey = createTransformedImageCacheKey({
+    ...commonOptions,
+    path: "photos/item.png",
+    archive: "",
+    key: "",
+  });
+  const archiveKey = createTransformedImageCacheKey({
+    ...commonOptions,
+    path: "photos.zip/item.png",
+    archive: "photos.zip",
+    key: "item.png",
+    encoding: "shift_jis",
+  });
+  const metadataKey = createTransformedImageCacheKey({
+    ...commonOptions,
+    path: "photos/item.png",
+    archive: "",
+    key: "",
+    keepMetadata: true,
+  });
+
+  expect(regularKey).not.toBe(archiveKey);
+  expect(regularKey).not.toBe(metadataKey);
+  expect(JSON.parse(archiveKey)).toMatchObject({
+    path: "photos.zip/item.png",
+    archive: "photos.zip",
+    key: "item.png",
+    encoding: "shift_jis",
+    mtime: 123,
+    size: 456,
+    width: "100",
+    height: "80",
+    fit: "inside",
+    format: "webp",
+    keepMetadata: false,
+  });
 });

--- a/backend/app.ts
+++ b/backend/app.ts
@@ -43,8 +43,96 @@ const archiveExtensions = [
 const maxMetadataTextLength = 16 * 1024;
 const maxInflatedMetadataTextLength = 256 * 1024;
 const pngSignature = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+const transformedImageCacheMaxEntries = 100;
+const transformedImageCacheMaxBytes = 64 * 1024 * 1024;
 
 const app = new Hono();
+
+type TransformedImageCacheKeyOptions = {
+  path: string;
+  archive: string;
+  key: string;
+  encoding?: string;
+  mtime: number;
+  size: number;
+  width?: string;
+  height?: string;
+  fit?: string;
+  format?: string;
+  keepMetadata: boolean;
+};
+
+type TransformedImageCacheEntry = {
+  buffer: Buffer;
+  size: number;
+};
+
+const transformedImageCache = new Map<string, TransformedImageCacheEntry>();
+let transformedImageCacheBytes = 0;
+
+export function createTransformedImageCacheKey(options: TransformedImageCacheKeyOptions) {
+  return JSON.stringify({
+    path: options.path,
+    archive: options.archive,
+    key: options.key,
+    encoding: options.encoding,
+    mtime: options.mtime,
+    size: options.size,
+    width: options.width,
+    height: options.height,
+    fit: options.fit,
+    format: options.format,
+    keepMetadata: options.keepMetadata,
+  });
+}
+
+function getTransformedImageCache(key: string) {
+  const entry = transformedImageCache.get(key);
+  if (!entry) {
+    return null;
+  }
+
+  transformedImageCache.delete(key);
+  transformedImageCache.set(key, entry);
+  return entry.buffer;
+}
+
+function pruneTransformedImageCache() {
+  while (
+    transformedImageCache.size > transformedImageCacheMaxEntries ||
+    transformedImageCacheBytes > transformedImageCacheMaxBytes
+  ) {
+    const oldestKey = transformedImageCache.keys().next().value;
+    if (oldestKey == null) {
+      return;
+    }
+    const oldestEntry = transformedImageCache.get(oldestKey);
+    transformedImageCache.delete(oldestKey);
+    if (oldestEntry) {
+      transformedImageCacheBytes -= oldestEntry.size;
+    }
+  }
+}
+
+function setTransformedImageCache(key: string, buffer: Buffer) {
+  const existing = transformedImageCache.get(key);
+  if (existing) {
+    transformedImageCacheBytes -= existing.size;
+    transformedImageCache.delete(key);
+  }
+
+  if (buffer.byteLength > transformedImageCacheMaxBytes) {
+    pruneTransformedImageCache();
+    return;
+  }
+
+  transformedImageCache.set(key, {
+    buffer,
+    size: buffer.byteLength,
+  });
+  transformedImageCacheBytes += buffer.byteLength;
+  pruneTransformedImageCache();
+}
 
 function decodeImageRequestPath(path: string) {
   try {
@@ -339,12 +427,14 @@ app.get("/.be/images/*", etag(), async (c) => {
   let header: AdbZip.EntryHeader | null = null;
   let mtime: number = 0;
   let fileSize: number = 0;
+  let archiveKey = "";
   if (archive) {
     const key = resolveArchiveKey(path, archive);
     if (key == null) {
       console.error(`Invalid path attempt: ${path}`);
       return c.json({ error: "File not found" }, 404);
     }
+    archiveKey = key;
 
     const archivePath = join(imagesDir, archive);
 
@@ -501,8 +591,30 @@ app.get("/.be/images/*", etag(), async (c) => {
         break;
     }
 
+    const transformedImageCacheKey = createTransformedImageCacheKey({
+      path,
+      archive,
+      key: archiveKey,
+      encoding: archive ? encoding : undefined,
+      mtime,
+      size: archive ? (header?.size ?? buffer?.byteLength ?? 0) : fileSize,
+      width: width || undefined,
+      height: height || undefined,
+      fit: fit || undefined,
+      format: format || undefined,
+      keepMetadata,
+    });
+    const cachedBuffer = getTransformedImageCache(transformedImageCacheKey);
+    if (cachedBuffer) {
+      return stream(c, async (stream) => {
+        await stream.write(cachedBuffer);
+      });
+    }
+
     return stream(c, async (stream) => {
-      await stream.write(await image.toBuffer());
+      const outputBuffer = await image.toBuffer();
+      setTransformedImageCache(transformedImageCacheKey, outputBuffer);
+      await stream.write(outputBuffer);
     });
   } catch (err) {
     if (


### PR DESCRIPTION
## Summary

- add a bounded process-local cache for sharp output buffers
- key cached buffers by source identity, transform options, and metadata mode
- cover cache reuse and key separation in backend tests

Closes #7

## Tests

- bun test backend/app.test.ts
- bunx tsc --noEmit