### PR TITLE
Make image ETags include source identity

### DIFF
--- a/backend/app.test.ts
+++ b/backend/app.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import sharp from "sharp";
+import AdmZip from "adm-zip";
 
 let app: { fetch: (request: Request) => Response | Promise<Response> };
 let tempDir: string;
@@ -80,6 +81,10 @@ beforeAll(async () => {
       createPngTextChunk("Comment", commentText),
     ),
   );
+  const archive = new AdmZip();
+  archive.addFile("first.png", basePng);
+  archive.addFile("second.png", basePng);
+  archive.writeZip(join(tempDir, "archive.zip"));
 
   process.argv = ["bun", "test", "--dir", tempDir, "--showMetadata"];
   ({ default: app } = await import("./app.ts"));
@@ -151,4 +156,25 @@ test("returns truncated PNG text metadata", async () => {
   });
   expect(metadata.textEntries[0].value).toStartWith("PNG comment PNG comment");
   expect(metadata.textEntries[0].value.length).toBe(16 * 1024);
+});
+
+test("uses distinct ETags for different images inside a ZIP archive", async () => {
+  const firstResponse = await app.fetch(
+    new Request(
+      "http://localhost/.be/images/archive.zip/first.png?archive=archive.zip",
+    ),
+  );
+  const secondResponse = await app.fetch(
+    new Request(
+      "http://localhost/.be/images/archive.zip/second.png?archive=archive.zip",
+    ),
+  );
+
+  expect(firstResponse.status).toBe(200);
+  expect(secondResponse.status).toBe(200);
+  expect(firstResponse.headers.get("ETag")).toBeTruthy();
+  expect(secondResponse.headers.get("ETag")).toBeTruthy();
+  expect(firstResponse.headers.get("ETag")).not.toBe(
+    secondResponse.headers.get("ETag"),
+  );
 });

--- a/backend/app.ts
+++ b/backend/app.ts
@@ -14,6 +14,7 @@ import { stream } from "hono/streaming";
 import { cors } from "hono/cors";
 import { join, extname, basename, dirname } from "node:path/posix";
 import { readFile, readdir, stat } from "node:fs/promises";
+import { createHash } from "node:crypto";
 import { inflateSync } from "node:zlib";
 import sharp from "sharp";
 import AdbZip from "adm-zip";
@@ -46,6 +47,10 @@ const pngSignature = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a
 
 const app = new Hono();
 
+type ImageEtagSource =
+  | { kind: "file"; path: string }
+  | { kind: "zip-entry"; archive: string; key: string };
+
 function decodeImageRequestPath(path: string) {
   try {
     return decodeURIComponent(path);
@@ -76,6 +81,30 @@ function resolveArchiveKey(path: string, archive: string) {
   }
 
   return path.slice(archive.length + 1);
+}
+
+function createImageEtag(input: {
+  mtime: number;
+  fileSize: number;
+  source: ImageEtagSource;
+  transform: {
+    width?: string;
+    height?: string;
+    fit?: string;
+    format?: string;
+  };
+  keepMetadata: boolean;
+}) {
+  const digest = createHash("sha256")
+    .update(JSON.stringify({
+      source: input.source,
+      transform: input.transform,
+      keepMetadata: input.keepMetadata,
+    }))
+    .digest("base64url")
+    .slice(0, 22);
+
+  return `${input.mtime.toString(16)}-${input.fileSize.toString(16)}-${digest}`;
 }
 
 function createMetadataTextEntry(
@@ -339,6 +368,7 @@ app.get("/.be/images/*", etag(), async (c) => {
   let header: AdbZip.EntryHeader | null = null;
   let mtime: number = 0;
   let fileSize: number = 0;
+  let etagSource: ImageEtagSource | null = null;
   if (archive) {
     const key = resolveArchiveKey(path, archive);
     if (key == null) {
@@ -358,6 +388,8 @@ app.get("/.be/images/*", etag(), async (c) => {
       return c.json({ error: "File not found" }, 404);
     }
     mtime = header?.time?.getTime() ?? 0;
+    fileSize = header.size;
+    etagSource = { kind: "zip-entry", archive, key };
   }
 
   const filePath = join(imagesDir, path);
@@ -373,6 +405,7 @@ app.get("/.be/images/*", etag(), async (c) => {
       }
       mtime = fileInfo.mtime.getTime();
       fileSize = fileInfo.size;
+      etagSource = { kind: "file", path };
     }
 
     // クエリパラメータからリサイズ設定を取得
@@ -415,27 +448,22 @@ app.get("/.be/images/*", etag(), async (c) => {
       image.keepMetadata()
     }
 
-    // ETag生成 (リサイズパラメータがある場合は含める)
-    let etagValue = `${mtime.toString(16)}-${fileSize.toString(16)}`;
-
-    if (keepMetadata) {
-      etagValue += "-km"
+    if (etagSource == null) {
+      return c.json({ error: "File not found" }, 404);
     }
 
-    if (width || height || fit || format) {
-      const paramsHash = Buffer.from(
-        JSON.stringify({
-          width: width || undefined,
-          height: height || undefined,
-          fit: fit || undefined,
-          format: format || undefined,
-        })
-      ).toString("hex");
-
-      etagValue = `${mtime.toString(16)}-${fileSize.toString(
-        16
-      )}-${paramsHash}`;
-    }
+    const etagValue = createImageEtag({
+      mtime,
+      fileSize,
+      source: etagSource,
+      transform: {
+        width: width || undefined,
+        height: height || undefined,
+        fit: fit || undefined,
+        format: format || undefined,
+      },
+      keepMetadata,
+    });
 
     c.header("ETag", `"${etagValue}"`);
 


### PR DESCRIPTION
## Summary

- include ZIP entry size when generating image ETags
- digest file/ZIP source identity, transform options, and metadata mode into ETags
- add coverage that different ZIP entries receive different ETags

Closes #4

## Tests

- bun test backend/app.test.ts
- bunx tsc --noEmit