### PR TITLE
Add finder view and thumbnail controls

### DIFF
--- a/frontend/finder/Controls.tsx
+++ b/frontend/finder/Controls.tsx
@@ -3,14 +3,21 @@ import {
   currentFileItemsQueryAtom,
   sortOptionAtom,
 } from "./states/fileList.ts";
-import { darkModeAtom } from "./states/display.ts";
+import {
+  type ThumbnailSize,
+  darkModeAtom,
+  thumbnailSizeAtom,
+  viewModeAtom,
+} from "./states/display.ts";
 import { globAtom } from "./states/location.ts";
 import type { SortOption } from "@/common/types.ts";
-import { FaRedo, FaMoon, FaSun } from "react-icons/fa";
+import { FaRedo, FaMoon, FaSun, FaThLarge, FaList } from "react-icons/fa";
 
 export default function Controls() {
   const [sortOption, setSortOption] = useAtom(sortOptionAtom);
   const [darkMode, setDarkMode] = useAtom(darkModeAtom);
+  const [viewMode, setViewMode] = useAtom(viewModeAtom);
+  const [thumbnailSize, setThumbnailSize] = useAtom(thumbnailSizeAtom);
   const [glob, setGlob] = useAtom(globAtom);
   const {
     refetch: refetchCurrentFileItems,
@@ -41,9 +48,40 @@ export default function Controls() {
         id="sort-option"
         value={sortOption}
         onChange={(e) => setSortOption(e.target.value as SortOption)}
+        aria-label="並び順"
       >
         <option value="name">名前順</option>
         <option value="date">更新日時順</option>
+      </select>
+      <div className="segmented-control" role="group" aria-label="表示モード">
+        <button
+          type="button"
+          className={viewMode === "grid" ? "active" : ""}
+          onClick={() => setViewMode("grid")}
+          aria-pressed={viewMode === "grid"}
+          aria-label="グリッド表示"
+        >
+          <FaThLarge />
+        </button>
+        <button
+          type="button"
+          className={viewMode === "list" ? "active" : ""}
+          onClick={() => setViewMode("list")}
+          aria-pressed={viewMode === "list"}
+          aria-label="リスト表示"
+        >
+          <FaList />
+        </button>
+      </div>
+      <select
+        id="thumbnail-size"
+        value={thumbnailSize}
+        onChange={(e) => setThumbnailSize(e.target.value as ThumbnailSize)}
+        aria-label="サムネイルサイズ"
+      >
+        <option value="small">小</option>
+        <option value="medium">中</option>
+        <option value="large">大</option>
       </select>
       <button
         onClick={() => setDarkMode(!darkMode)}

--- a/frontend/finder/FileContainer.tsx
+++ b/frontend/finder/FileContainer.tsx
@@ -3,6 +3,11 @@ import type { FileItem } from "@/common/types.ts";
 import { currentFileItemsQueryAtom, filesListAtom } from "./states/fileList.ts";
 import { currentImagesAtom, onImageModalOpenAtom } from "./states/image.ts";
 import {
+  type ThumbnailSize,
+  thumbnailSizeAtom,
+  viewModeAtom,
+} from "./states/display.ts";
+import {
   type Navigation,
   locationAtom,
   urlOfLocation,
@@ -21,6 +26,7 @@ export function IconWithName({
   children,
   width,
   height,
+  metadata,
   style,
 }: {
   icon: string;
@@ -31,6 +37,7 @@ export function IconWithName({
   children?: React.ReactNode;
   width: number;
   height: number;
+  metadata?: React.ReactNode;
   style?: React.CSSProperties;
 }) {
   const iconStyle = {
@@ -54,6 +61,7 @@ export function IconWithName({
         )}
       </div>
       <div className="file-name">{file.name}</div>
+      {metadata ? <div className="file-meta">{metadata}</div> : null}
     </a>
   );
 }
@@ -62,10 +70,12 @@ export function FolderIcon({
   file,
   width,
   height,
+  metadata,
 }: {
   file: FileItem;
   width: number;
   height: number;
+  metadata?: React.ReactNode;
 }) {
   const [location, setLocation] = useAtom(locationAtom);
   const onNavigate = (navigation: Navigation) => {
@@ -102,6 +112,7 @@ export function FolderIcon({
       }
       onClick={handleClick}
       onKeyDown={handleKeyDown}
+      metadata={metadata}
     />
   );
 }
@@ -110,10 +121,12 @@ export function ImageIcon({
   file,
   width,
   height,
+  metadata,
 }: {
   file: FileItem;
   width: number;
   height: number;
+  metadata?: React.ReactNode;
 }) {
   const location = useAtomValue(locationAtom);
   const onImageModalOpen = useSetAtom(onImageModalOpenAtom);
@@ -167,6 +180,7 @@ export function ImageIcon({
       }
       onClick={handleClick}
       onKeyDown={handleKeyDown}
+      metadata={metadata}
     >
       <img
         loading="lazy"
@@ -186,37 +200,118 @@ export function RegularFileIcon({
   file,
   width,
   height,
+  metadata,
 }: {
   file: FileItem;
   width: number;
   height: number;
+  metadata?: React.ReactNode;
 }) {
-  return <IconWithName icon="📄" file={file} width={width} height={height} />;
+  return (
+    <IconWithName
+      icon="📄"
+      file={file}
+      width={width}
+      height={height}
+      metadata={metadata}
+    />
+  );
 }
 
 export function FileIcon({
   file,
   width = 150,
   height = 150,
+  metadata,
 }: {
   file: FileItem;
   width?: number;
   height?: number;
+  metadata?: React.ReactNode;
 }) {
   if (file.isDirectory || file.isArchive)
-    return <FolderIcon file={file} width={width} height={height} />;
+    return (
+      <FolderIcon
+        file={file}
+        width={width}
+        height={height}
+        metadata={metadata}
+      />
+    );
   if (file.isImage)
-    return <ImageIcon file={file} width={width} height={height} />;
-  return <RegularFileIcon file={file} width={width} height={height} />;
+    return (
+      <ImageIcon file={file} width={width} height={height} metadata={metadata} />
+    );
+  return (
+    <RegularFileIcon
+      file={file}
+      width={width}
+      height={height}
+      metadata={metadata}
+    />
+  );
+}
+
+const thumbnailDimensions: Record<
+  ThumbnailSize,
+  { cardWidth: number; gridHeight: number; listHeight: number }
+> = {
+  small: { cardWidth: 150, gridHeight: 110, listHeight: 48 },
+  medium: { cardWidth: 200, gridHeight: 150, listHeight: 64 },
+  large: { cardWidth: 260, gridHeight: 220, listHeight: 80 },
+};
+
+function formatFileSize(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes < 0) return "";
+  if (bytes === 0) return "0 B";
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  const index = Math.min(
+    Math.floor(Math.log(bytes) / Math.log(1024)),
+    units.length - 1
+  );
+  const value = bytes / 1024 ** index;
+  const fractionDigits = value >= 10 || index === 0 ? 0 : 1;
+  return `${value.toFixed(fractionDigits)} ${units[index]}`;
+}
+
+function formatModifiedTime(modified: number): string {
+  if (!Number.isFinite(modified) || modified <= 0) return "";
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(modified));
+}
+
+function FileMetadata({ file }: { file: FileItem }) {
+  const size = file.isDirectory ? "" : formatFileSize(file.size);
+  const modified = formatModifiedTime(file.modified);
+  return (
+    <>
+      {size ? <span>{size}</span> : null}
+      {modified ? <span>{modified}</span> : null}
+    </>
+  );
 }
 
 export default function FileContainer() {
   const [{ isLoading }] = useAtom(currentFileItemsQueryAtom);
+  const viewMode = useAtomValue(viewModeAtom);
+  const thumbnailSize = useAtomValue(thumbnailSizeAtom);
 
   const files: FileItem[] = useAtomValue(filesListAtom);
+  const dimensions = thumbnailDimensions[thumbnailSize];
+  const iconHeight =
+    viewMode === "grid" ? dimensions.gridHeight : dimensions.listHeight;
+  const containerStyle = {
+    "--grid-card-min": `${dimensions.cardWidth}px`,
+  } as React.CSSProperties;
 
   return (
-    <div id="file-container">
+    <div
+      id="file-container"
+      className={`file-container-${viewMode}`}
+      style={containerStyle}
+    >
       {isLoading ? (
         <div className="loading-overlay">
           <div className="loading-spinner"></div>
@@ -224,7 +319,13 @@ export default function FileContainer() {
         </div>
       ) : null}
       {files.map((file, i) => (
-        <FileIcon key={file.name} file={file} />
+        <FileIcon
+          key={`${file.archive}:${file.path}:${i}`}
+          file={file}
+          width={dimensions.cardWidth}
+          height={iconHeight}
+          metadata={<FileMetadata file={file} />}
+        />
       ))}
     </div>
   );

--- a/frontend/finder/states/display.ts
+++ b/frontend/finder/states/display.ts
@@ -1,9 +1,19 @@
 import { atomWithStorage } from "jotai/utils";
 import { atomEffect } from "jotai-effect";
 
+export type ViewMode = "grid" | "list";
+export type ThumbnailSize = "small" | "medium" | "large";
+
 export const darkModeAtom = atomWithStorage<boolean>(
   "darkMode",
   window.matchMedia("(prefers-color-scheme: dark)").matches
+);
+
+export const viewModeAtom = atomWithStorage<ViewMode>("viewMode", "grid");
+
+export const thumbnailSizeAtom = atomWithStorage<ThumbnailSize>(
+  "thumbnailSize",
+  "medium"
 );
 
 export const htmlClassAtom = atomEffect((get) => {
@@ -18,6 +28,6 @@ export const htmlClassAtom = atomEffect((get) => {
     classList.remove("dark");
   }
   if (!first) {
-    classList.add("transition")
+    classList.add("transition");
   }
 });

--- a/frontend/finder/style.css
+++ b/frontend/finder/style.css
@@ -52,10 +52,16 @@ body {
 
 #file-container {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(var(--grid-card-min, 200px), 1fr));
   gap: 20px;
   margin: 24px 0 80px;
   padding: 0 16px;
+}
+
+#file-container.file-container-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 }
 
 .file-item {
@@ -114,6 +120,52 @@ body {
   flex-shrink: 0;
 }
 
+.file-meta {
+  display: none;
+}
+
+.file-container-list .file-item {
+  display: grid;
+  grid-template-columns: minmax(56px, 88px) minmax(0, 1fr) auto;
+  gap: 12px;
+  align-items: center;
+  min-height: var(--thumbnail-height, 64px);
+  height: auto;
+}
+
+.file-container-list .file-item:hover,
+.file-container-list .file-item:focus-within,
+.file-container-list .file-item:focus-visible {
+  transform: translateY(-1px);
+}
+
+.file-container-list .file-icon {
+  width: 100%;
+  min-height: var(--thumbnail-height, 64px);
+  height: var(--thumbnail-height, 64px);
+  flex-grow: 0;
+  border-radius: 6px 0 0 6px;
+  overflow: hidden;
+}
+
+.file-container-list .file-name {
+  padding: 8px 0;
+  text-align: left;
+  font-size: 0.9rem;
+  white-space: normal;
+  overflow-wrap: anywhere;
+}
+
+.file-container-list .file-meta {
+  display: flex;
+  gap: 16px;
+  justify-content: flex-end;
+  padding: 8px 12px 8px 0;
+  color: var(--placeholder-color);
+  font-size: 0.8rem;
+  white-space: nowrap;
+}
+
 .image-thumbnail {
   width: 100%;
   height: 100%;
@@ -126,6 +178,7 @@ body {
   flex-wrap: wrap;
   gap: 8px;
   align-items: center;
+  max-width: 100%;
 }
 
 button,
@@ -182,6 +235,74 @@ button:focus-visible,
   }
   &:hover svg {
     color: var(--link-color);
+  }
+}
+
+.segmented-control {
+  display: inline-flex;
+  border: 1px solid var(--button-border);
+  border-radius: 4px;
+  overflow: hidden;
+  flex-shrink: 0;
+}
+
+.segmented-control button {
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.segmented-control button + button {
+  border-left: 1px solid var(--button-border);
+}
+
+.segmented-control button.active {
+  color: var(--link-color);
+  background: var(--card-bg);
+}
+
+.segmented-control svg {
+  width: 15px;
+  height: 15px;
+}
+
+@media (max-width: 768px) {
+  #controls {
+    width: 100%;
+  }
+
+  .search-input {
+    flex: 1 1 180px;
+    min-width: 0;
+  }
+}
+
+@media (max-width: 560px) {
+  #file-container {
+    padding: 0 12px;
+  }
+
+  #file-container.file-container-list {
+    gap: 10px;
+  }
+
+  .file-container-list .file-item {
+    grid-template-columns: minmax(52px, 72px) minmax(0, 1fr);
+    gap: 10px;
+  }
+
+  .file-container-list .file-meta {
+    grid-column: 2;
+    justify-content: flex-start;
+    flex-wrap: wrap;
+    gap: 4px 12px;
+    padding: 0 10px 8px 0;
+    white-space: normal;
   }
 }
 


### PR DESCRIPTION
## Summary

- add grid/list view mode controls
- add small/medium/large thumbnail size controls
- persist view preferences in localStorage
- show file size and modified time in list view

Closes #8

## Tests

- bun test
- bunx tsc --noEmit
- local server smoke check on http://127.0.0.1:8001/ with HTML, API, JS, and CSS responses

Note: Playwright screenshot verification was attempted but the local Playwright browser executable was not installed.