### PR TITLE
Add text file preview modal

### DIFF
--- a/backend/app.test.ts
+++ b/backend/app.test.ts
@@ -101,6 +101,8 @@ beforeAll(async () => {
   await writeFile(join(tempDir, "cache.png"), cacheOriginalPng);
   await writeFile(join(tempDir, "sort-small.jpg"), Buffer.alloc(10));
   await writeFile(join(tempDir, "sort-large.jpg"), Buffer.alloc(20));
+  await writeFile(join(tempDir, "notes.md"), "# Notes\n\nHello text viewer.\n");
+  await writeFile(join(tempDir, "large.txt"), Buffer.alloc(1024 * 1024 + 1, "a"));
   const archive = new AdmZip();
   archive.addFile("first.png", basePng);
   archive.addFile("second.png", basePng);
@@ -109,6 +111,7 @@ beforeAll(async () => {
   zip.addFile("UPPER.JPG", basePng);
   zip.addFile("PHOTO.PNG", basePng);
   zip.addFile("notes.txt", Buffer.from("not an image"));
+  zip.addFile("readme.md", Buffer.from("# Archive note\n"));
   await writeFile(join(tempDir, "upper-extensions.zip"), zip.toBuffer());
 
   process.argv = ["bun", "test", "--dir", tempDir, "--showMetadata"];
@@ -198,6 +201,48 @@ test("returns image metadata when enabled", async () => {
   expect(metadata.width).toBe(2);
   expect(metadata.height).toBe(2);
   expect(metadata.size).toBeGreaterThan(0);
+});
+
+test("returns UTF-8 text file content", async () => {
+  const response = await app.fetch(
+    new Request("http://localhost/.be/api/text-file?path=notes.md"),
+  );
+
+  expect(response.status).toBe(200);
+  const content = await response.json();
+  expect(content).toMatchObject({
+    path: "notes.md",
+    archive: "",
+    name: "notes.md",
+    content: "# Notes\n\nHello text viewer.\n",
+  });
+  expect(content.size).toBeGreaterThan(0);
+});
+
+test("rejects text file content above the size limit", async () => {
+  const response = await app.fetch(
+    new Request("http://localhost/.be/api/text-file?path=large.txt"),
+  );
+
+  expect(response.status).toBe(413);
+  expect(await response.json()).toEqual({ error: "File too large" });
+});
+
+test("returns text file content inside ZIP archives", async () => {
+  const response = await app.fetch(
+    new Request(
+      "http://localhost/.be/api/text-file?archive=upper-extensions.zip&path=upper-extensions.zip%2Freadme.md",
+    ),
+  );
+
+  expect(response.status).toBe(200);
+  const content = await response.json();
+  expect(content).toMatchObject({
+    path: "upper-extensions.zip/readme.md",
+    archive: "upper-extensions.zip",
+    name: "readme.md",
+    content: "# Archive note\n",
+  });
 });
 
 test("returns truncated PNG text metadata", async () => {
@@ -361,6 +406,15 @@ test("recognizes uppercase image extensions inside ZIP archives", async () => {
     expect.objectContaining({
       name: "notes.txt",
       isImage: false,
+      isText: true,
+      isArchive: false,
+    }),
+  );
+  expect(listing.files).toContainEqual(
+    expect.objectContaining({
+      name: "readme.md",
+      isImage: false,
+      isText: true,
       isArchive: false,
     }),
   );

--- a/backend/app.ts
+++ b/backend/app.ts
@@ -26,6 +26,7 @@ import type {
   RuntimeFeatureOptions,
   SortOption,
   SortOrder,
+  TextFileContent,
 } from "@/common/types";
 
 const imageExtensions = [
@@ -43,6 +44,19 @@ const archiveExtensions = [
   ".zip",
 ];
 
+const textExtensions = [
+  ".txt",
+  ".md",
+  ".json",
+  ".csv",
+  ".tsv",
+  ".log",
+  ".yaml",
+  ".yml",
+  ".xml",
+];
+
+const maxTextFileBytes = 1024 * 1024;
 const maxMetadataTextLength = 16 * 1024;
 const maxInflatedMetadataTextLength = 256 * 1024;
 const pngSignature = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
@@ -199,6 +213,10 @@ function isInvalidImagePath(path: string) {
     path.includes("\\") ||
     path.split("/").some((part: string) => part.startsWith(".") || part.length === 0)
   );
+}
+
+function isTextPath(path: string) {
+  return textExtensions.includes(extname(path).toLowerCase());
 }
 
 function resolveArchiveKey(path: string, archive: string) {
@@ -801,6 +819,84 @@ app.get("/.be/api/image-metadata", async (c) => {
   }
 });
 
+app.get("/.be/api/text-file", async (c) => {
+  const { path = "", archive = "", encoding = "shift_jis" } = c.req.query();
+
+  if (path === "" || isInvalidImagePath(path) || !isTextPath(path)) {
+    console.error(`Invalid text path attempt: ${path}`);
+    return c.json({ error: "File not found" }, 404);
+  }
+
+  try {
+    if (archive) {
+      const key = resolveArchiveKey(path, archive);
+      if (key == null) {
+        console.error(`Invalid text path attempt: ${path}`);
+        return c.json({ error: "File not found" }, 404);
+      }
+
+      const archivePath = join(imagesDir, archive);
+      const zip = new AdbZip(archivePath);
+      const rawKey = iconv.encode(key, encoding).toString("utf-8");
+      const header = zip.getEntry(rawKey)?.header ?? null;
+      if (!header) {
+        return c.json({ error: "File not found" }, 404);
+      }
+      if (header.size > maxTextFileBytes) {
+        return c.json({ error: "File too large" }, 413);
+      }
+
+      const buffer = zip.readFile(rawKey) ?? null;
+      if (!buffer) {
+        return c.json({ error: "File not found" }, 404);
+      }
+
+      const result: TextFileContent = {
+        path,
+        archive,
+        name: basename(path),
+        size: header.size,
+        modified: header.time?.getTime() ?? 0,
+        content: buffer.toString("utf8"),
+      };
+      return c.json(result);
+    }
+
+    const filePath = join(imagesDir, path);
+    const fileInfo = await stat(filePath);
+    if (!fileInfo.isFile()) {
+      console.error(`Not a regular text file: ${filePath}`);
+      return c.json({ error: "File not found" }, 404);
+    }
+    if (fileInfo.size > maxTextFileBytes) {
+      return c.json({ error: "File too large" }, 413);
+    }
+
+    const result: TextFileContent = {
+      path,
+      archive,
+      name: basename(path),
+      size: fileInfo.size,
+      modified: fileInfo.mtime.getTime(),
+      content: await readFile(filePath, "utf8"),
+    };
+    return c.json(result);
+  } catch (err) {
+    if ((err as any)?.code === "ENOENT") {
+      return c.json({ error: "File not found" }, 404);
+    }
+    if ((err as any)?.code === "ERR_ENCODING_INVALID_ENCODED_DATA") {
+      return c.json({ error: "Unable to decode text file" }, 415);
+    }
+    console.error(
+      `Error processing text-file request for ${path}:`,
+      err?.constructor,
+      err
+    );
+    return c.json({ error: "Internal server error" }, 500);
+  }
+});
+
 // ファイル一覧取得API
 app.get("/.be/api/list-files", async (c) => {
   const {
@@ -844,11 +940,13 @@ app.get("/.be/api/list-files", async (c) => {
       const isDirectory = entryName.endsWith("/");
       const ext = extname(file).toLowerCase();
       const isImage = imageExtensions.includes(ext);
+      const isText = textExtensions.includes(ext);
       const isArchive = false;
       items.push({
         name: file,
         isDirectory,
         isImage,
+        isText,
         isArchive,
         modified: entry.header.time.getTime(),
         size: entry.header.size,
@@ -882,12 +980,14 @@ app.get("/.be/api/list-files", async (c) => {
         const fileInfo = await stat(fsFilePath);
         const isDirectory = fileInfo.isDirectory();
         const isImage = imageExtensions.includes(ext);
+        const isText = textExtensions.includes(ext);
         const isArchive = archiveExtensions.includes(ext);
         const filePath = join(path, fileName);
         items.push({
           name: fileName,
           isDirectory,
           isImage,
+          isText,
           isArchive,
           modified: fileInfo.mtime.getTime(),
           size: fileInfo.size,
@@ -903,6 +1003,7 @@ app.get("/.be/api/list-files", async (c) => {
             name: fileName,
             isDirectory: false,
             isImage: false,
+            isText: false,
             isArchive: false,
             modified: 0,
             size: 0,

--- a/bun.lock
+++ b/bun.lock
@@ -8,28 +8,29 @@
         "@tanstack/query-core": "^5.90.20",
         "@types/path-browserify": "^1.0.3",
         "adm-zip": "^0.5.16",
-        "hono": "^4.11.7",
+        "hono": "^4.12.8",
         "iconv-lite": "^0.7.2",
-        "immer": "^11.1.3",
-        "jotai": "^2.17.0",
+        "immer": "^11.1.4",
+        "jotai": "^2.18.1",
         "jotai-effect": "^2.2.3",
         "jotai-location": "^0.6.2",
         "jotai-optics": "^0.4.0",
         "jotai-tanstack-query": "^0.11.0",
-        "minimatch": "^10.1.1",
+        "minimatch": "^10.2.4",
         "optics-ts": "^2.4.1",
         "path-browserify": "^1.0.1",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
-        "react-icons": "^5.5.0",
+        "react-icons": "^5.6.0",
         "react-swipeable": "^7.0.2",
         "sharp": "^0.34.5",
       },
       "devDependencies": {
+        "@playwright/test": "^1.59.1",
         "@types/adm-zip": "^0.5.7",
-        "@types/bun": "^1.3.8",
+        "@types/bun": "^1.3.10",
         "@types/hammerjs": "^2.0.46",
-        "@types/react": "^19.2.10",
+        "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
       },
       "peerDependencies": {
@@ -113,6 +114,8 @@
 
     "@oven/bun-windows-x64-baseline": ["@oven/bun-windows-x64-baseline@1.3.4", "", { "os": "win32", "cpu": "x64" }, "sha512-ZQiSDFfSUdOrPTiL2GvkxlC/kMED4fsJwdZnwJK6S9ylXnk9xY/9ZXfe1615SFLQl2LsVRzJAtjQLeM0BifIKQ=="],
 
+    "@playwright/test": ["@playwright/test@1.59.1", "", { "dependencies": { "playwright": "1.59.1" }, "bin": { "playwright": "cli.js" } }, "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg=="],
+
     "@tanstack/query-core": ["@tanstack/query-core@5.90.20", "", {}, "sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg=="],
 
     "@types/adm-zip": ["@types/adm-zip@0.5.7", "", { "dependencies": { "@types/node": "*" } }, "sha512-DNEs/QvmyRLurdQPChqq0Md4zGvPwHerAJYWk9l2jCbD1VPpnzRJorOdiq4zsw09NFbYnhfsoEhWtxIzXpn2yw=="],
@@ -143,6 +146,8 @@
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
+    "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
+
     "hono": ["hono@4.12.8", "", {}, "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A=="],
 
     "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
@@ -164,6 +169,10 @@
     "optics-ts": ["optics-ts@2.4.1", "", {}, "sha512-HaYzMHvC80r7U/LqAd4hQyopDezC60PO2qF5GuIwALut2cl5rK1VWHsqTp0oqoJJWjiv6uXKqsO+Q2OO0C3MmQ=="],
 
     "path-browserify": ["path-browserify@1.0.1", "", {}, "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="],
+
+    "playwright": ["playwright@1.59.1", "", { "dependencies": { "playwright-core": "1.59.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw=="],
+
+    "playwright-core": ["playwright-core@1.59.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg=="],
 
     "react": ["react@19.2.4", "", {}, "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ=="],
 

--- a/common/types.ts
+++ b/common/types.ts
@@ -4,6 +4,7 @@ export type FileItem = {
   name: string;
   isDirectory: boolean;
   isImage: boolean;
+  isText: boolean;
   isArchive: boolean;
   modified: number;
   size: number;
@@ -43,4 +44,13 @@ export type ImageMetadata = {
   size: number;
   modified: number;
   textEntries?: MetadataTextEntry[];
+};
+
+export type TextFileContent = {
+  path: string;
+  archive: string;
+  name: string;
+  size: number;
+  modified: number;
+  content: string;
 };

--- a/frontend/finder/FileContainer.tsx
+++ b/frontend/finder/FileContainer.tsx
@@ -2,6 +2,7 @@ import { useAtom, useAtomValue, useSetAtom } from "jotai";
 import type { FileItem } from "@/common/types.ts";
 import { currentFileItemsQueryAtom, filesListAtom } from "./states/fileList.ts";
 import { currentImagesAtom, onImageModalOpenAtom } from "./states/image.ts";
+import { onTextModalOpenAtom } from "./states/text.ts";
 import {
   type ThumbnailSize,
   thumbnailSizeAtom,
@@ -12,6 +13,7 @@ import {
   locationAtom,
   urlOfLocation,
   navigationForImage,
+  navigationForText,
   navigationForDir,
   navigated,
 } from "./states/location.ts";
@@ -214,6 +216,59 @@ export function RegularFileIcon({
   );
 }
 
+export function TextFileIcon({
+  file,
+  width,
+  height,
+  metadata,
+}: {
+  file: FileItem;
+  width: number;
+  height: number;
+  metadata?: React.ReactNode;
+}) {
+  const location = useAtomValue(locationAtom);
+  const onTextModalOpen = useSetAtom(onTextModalOpenAtom);
+
+  const openText = () => {
+    onTextModalOpen(file.path);
+  };
+
+  const handleClick = (e: React.MouseEvent) => {
+    if (e.button === 0 && !(e.metaKey || e.altKey || e.ctrlKey || e.shiftKey)) {
+      e.preventDefault();
+      openText();
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (
+      (e.key === "Enter" || e.key === " ") &&
+      !(e.metaKey || e.altKey || e.ctrlKey || e.shiftKey)
+    ) {
+      e.preventDefault();
+      openText();
+    }
+  };
+
+  return (
+    <IconWithName
+      icon="📝"
+      file={file}
+      width={width}
+      height={height}
+      href={
+        urlOfLocation(
+          navigated(location, navigationForText(file.path, file.archive))
+        ).href
+      }
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
+      metadata={metadata}
+    />
+  );
+}
+
 export function FileIcon({
   file,
   width = 150,
@@ -237,6 +292,15 @@ export function FileIcon({
   if (file.isImage)
     return (
       <ImageIcon file={file} width={width} height={height} metadata={metadata} />
+    );
+  if (file.isText)
+    return (
+      <TextFileIcon
+        file={file}
+        width={width}
+        height={height}
+        metadata={metadata}
+      />
     );
   return (
     <RegularFileIcon

--- a/frontend/finder/Finder.tsx
+++ b/frontend/finder/Finder.tsx
@@ -1,6 +1,7 @@
 import { useAtom } from "jotai";
 
 import ImageModal from "./ImageModal.tsx";
+import TextModal from "./TextModal.tsx";
 import Controls from "./Controls.tsx";
 import Breadcrumbs from "./Breadcrumbs.tsx";
 import FileContainer from "./FileContainer.tsx";
@@ -13,6 +14,7 @@ export default function Finder() {
       <div className="header-container">
         <h1 className="app-header">Image Viewer</h1>
         <ImageModal />
+        <TextModal />
         <Breadcrumbs />
         <Controls />
       </div>

--- a/frontend/finder/TextModal.css
+++ b/frontend/finder/TextModal.css
@@ -1,0 +1,76 @@
+.text-modal-panel {
+  position: absolute;
+  inset: 20px;
+  display: grid;
+  grid-template-rows: auto 1fr;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 8px;
+  background: rgba(18, 18, 18, 0.96);
+  color: white;
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.48);
+  user-select: text;
+}
+
+.text-modal-header {
+  display: grid;
+  gap: 4px;
+  padding: 16px 72px 14px 18px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.14);
+}
+
+.text-modal-title {
+  margin: 0;
+  overflow-wrap: anywhere;
+  font-size: 16px;
+  line-height: 1.35;
+}
+
+.text-modal-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 14px;
+  color: rgba(255, 255, 255, 0.64);
+  font-size: 12px;
+}
+
+.text-modal-body {
+  min-height: 0;
+  overflow: auto;
+}
+
+.text-modal-content {
+  min-height: 100%;
+  box-sizing: border-box;
+  margin: 0;
+  padding: 16px 18px 28px;
+  color: rgba(255, 255, 255, 0.9);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 13px;
+  line-height: 1.55;
+  overflow-wrap: normal;
+  white-space: pre-wrap;
+}
+
+.text-modal-status {
+  margin: 0;
+  padding: 18px;
+  color: rgba(255, 255, 255, 0.72);
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+@media (max-width: 560px) {
+  .text-modal-panel {
+    inset: 12px;
+  }
+
+  .text-modal-header {
+    padding-left: 14px;
+  }
+
+  .text-modal-content {
+    padding: 14px 14px 24px;
+    font-size: 12px;
+  }
+}

--- a/frontend/finder/TextModal.tsx
+++ b/frontend/finder/TextModal.tsx
@@ -1,0 +1,173 @@
+import { useAtom, useAtomValue, useStore } from "jotai";
+import { useCallback, useEffect, useRef, useState } from "react";
+import "./ImageModal.css";
+import "./TextModal.css";
+
+import { CloseButton } from "./ImageModal.tsx";
+import { fetchTextFileContent } from "./api.ts";
+import { currentArchiveAtom } from "./states/location.ts";
+import {
+  isTextModalOpenAtom,
+  selectedTextPathAtom,
+} from "./states/text.ts";
+import type { TextFileContent } from "@/common/types.ts";
+
+function formatBytes(size: number) {
+  if (size < 1024) return `${size} B`;
+  const units = ["KB", "MB", "GB"];
+  let value = size / 1024;
+  for (const unit of units) {
+    if (value < 1024 || unit === units[units.length - 1]) {
+      return `${value.toFixed(value < 10 ? 1 : 0)} ${unit}`;
+    }
+    value /= 1024;
+  }
+  return `${size} B`;
+}
+
+function formatDate(timestamp: number) {
+  if (timestamp <= 0) return "";
+  return new Date(timestamp).toLocaleString();
+}
+
+function statusText(error: string | null) {
+  if (!error) return "Loading...";
+  if (error.startsWith("Error 413:")) {
+    return "ファイルが大きすぎるため表示できません。";
+  }
+  if (error.startsWith("Error 415:")) {
+    return "テキストとして読み込めませんでした。";
+  }
+  return "テキストを読み込めませんでした。";
+}
+
+export default function TextModal() {
+  const store = useStore();
+  const [isTextModalOpen, setIsTextModalOpen] = useAtom(isTextModalOpenAtom);
+  const selectedTextPath = useAtomValue(selectedTextPathAtom);
+  const archive = useAtomValue(currentArchiveAtom);
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const [content, setContent] = useState<TextFileContent | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    if (!isTextModalOpen || !selectedTextPath) {
+      setContent(null);
+      setError(null);
+      setIsLoading(false);
+      return;
+    }
+
+    let ignore = false;
+    setIsLoading(true);
+    setError(null);
+    setContent(null);
+    fetchTextFileContent(selectedTextPath, archive)
+      .then((nextContent) => {
+        if (!ignore) {
+          setContent(nextContent);
+        }
+      })
+      .catch((err) => {
+        if (!ignore) {
+          setError(String(err?.message ?? err));
+        }
+      })
+      .finally(() => {
+        if (!ignore) {
+          setIsLoading(false);
+        }
+      });
+
+    return () => {
+      ignore = true;
+    };
+  }, [archive, isTextModalOpen, selectedTextPath]);
+
+  const closeModal = useCallback(() => {
+    setIsTextModalOpen(false);
+    dialogRef.current?.close();
+  }, [setIsTextModalOpen]);
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+
+    const handleClose = () => {
+      const path = store.get(selectedTextPathAtom);
+      const fileName = path.split("/").pop();
+      if (fileName) {
+        requestAnimationFrame(() => {
+          const el = Array.from(
+            document.querySelectorAll<HTMLElement>(".file-item")
+          ).find((item) => item.dataset.fileName === fileName);
+          el?.focus();
+        });
+      }
+      store.set(isTextModalOpenAtom, false);
+    };
+
+    dialog.addEventListener("close", handleClose);
+    dialog.addEventListener("cancel", handleClose);
+
+    if (isTextModalOpen) {
+      if (!dialog.open) {
+        dialog.showModal();
+      }
+      document.body.style.overflow = "hidden";
+    } else {
+      if (dialog.open) {
+        dialog.close();
+      }
+      document.body.style.overflow = "";
+    }
+
+    return () => {
+      dialog.removeEventListener("close", handleClose);
+      dialog.removeEventListener("cancel", handleClose);
+      document.body.style.overflow = "";
+    };
+  }, [isTextModalOpen, store]);
+
+  const onClick = useCallback((e: React.MouseEvent) => {
+    const dialog = dialogRef.current;
+    if (e.target === dialog) {
+      dialog.close();
+    }
+  }, []);
+
+  const modified = content ? formatDate(content.modified) : "";
+
+  return (
+    <dialog
+      aria-label="Text file"
+      ref={dialogRef}
+      className="dialog-modal"
+      onClick={onClick}
+      onClose={closeModal}
+    >
+      <CloseButton closeModal={closeModal} />
+      <section className="text-modal-panel">
+        <header className="text-modal-header">
+          <h2 className="text-modal-title">
+            {content?.name ?? selectedTextPath.split("/").pop() ?? "Text file"}
+          </h2>
+          {content && (
+            <div className="text-modal-meta">
+              <span>{formatBytes(content.size)}</span>
+              {modified ? <span>{modified}</span> : null}
+            </div>
+          )}
+        </header>
+        <div className="text-modal-body">
+          {isLoading || error ? (
+            <p className="text-modal-status">{statusText(error)}</p>
+          ) : (
+            <pre className="text-modal-content">{content?.content ?? ""}</pre>
+          )}
+        </div>
+      </section>
+    </dialog>
+  );
+}

--- a/frontend/finder/api.ts
+++ b/frontend/finder/api.ts
@@ -5,6 +5,7 @@ import type {
   RuntimeFeatureOptions,
   SortOrder,
   SortOption,
+  TextFileContent,
 } from "@/common/types.ts";
 
 const beDir = new URL(`${backendUrl}/`);
@@ -40,6 +41,21 @@ export async function fetchImageMetadata(
 ): Promise<ImageMetadata> {
   const response = await fetch(
     `${beDir.href}api/image-metadata?path=${encodeURIComponent(
+      path
+    )}&archive=${encodeURIComponent(archive)}`
+  );
+  if (!response.ok) {
+    throw new Error(`Error ${response.status}: ${response.statusText}`);
+  }
+  return await response.json();
+}
+
+export async function fetchTextFileContent(
+  path: string,
+  archive: string,
+): Promise<TextFileContent> {
+  const response = await fetch(
+    `${beDir.href}api/text-file?path=${encodeURIComponent(
       path
     )}&archive=${encodeURIComponent(archive)}`
   );

--- a/frontend/finder/states/image.ts
+++ b/frontend/finder/states/image.ts
@@ -1,6 +1,10 @@
 import { atom } from "jotai";
 import type { FileItem } from "@/common/types.ts";
-import { currentPathAtom, selectedImageNameAtom } from "./location.ts";
+import {
+  currentPathAtom,
+  selectedImageNameAtom,
+  selectedTextNameAtom,
+} from "./location.ts";
 import { filesListAtom } from "./fileList.ts";
 
 export const isImageModalOpenAtom = atom(
@@ -38,6 +42,7 @@ export const selectedImagePathAtom = atom((get) => {
 export const onImageModalOpenAtom = atom(
   null,
   (_get, set, imageName: string, index: number) => {
+    set(selectedTextNameAtom, "");
     set(selectedImageNameAtom, imageName);
   }
 );

--- a/frontend/finder/states/location.ts
+++ b/frontend/finder/states/location.ts
@@ -6,6 +6,7 @@ import { resolve, dirname, basename } from "path-browserify";
 export interface LocationState {
   path: string;
   image: string;
+  text: string;
   archive: string;
   glob: string;
 }
@@ -21,6 +22,7 @@ export function urlOfLocation(location: LocationState): URL {
   url.pathname = resolve("/", location.path);
   url.search = "";
   if (location.image) url.searchParams.set("image", location.image);
+  if (location.text) url.searchParams.set("text", location.text);
   if (location.archive) url.searchParams.set("archive", location.archive);
   if (location.glob) url.searchParams.set("glob", location.glob);
   return url;
@@ -31,6 +33,7 @@ export function locationOfUrl(url: URL): LocationState {
   return {
     path: decodeURI(url.pathname).slice(1),
     image: searchParams?.get("image") ?? "",
+    text: searchParams?.get("text") ?? "",
     archive: searchParams?.get("archive") ?? "",
     glob: searchParams?.get("glob") ?? "",
   };
@@ -44,6 +47,7 @@ export function navigationForDir(path: string, archive: string): Navigation {
   return {
     path,
     image: "",
+    text: "",
     archive,
     glob: "",
   }
@@ -53,6 +57,16 @@ export function navigationForImage(path: string, archive: string): Navigation {
   return {
     path: dirname(path),
     image: basename(path),
+    text: "",
+    archive,
+  }
+}
+
+export function navigationForText(path: string, archive: string): Navigation {
+  return {
+    path: dirname(path),
+    image: "",
+    text: basename(path),
     archive,
   }
 }
@@ -88,4 +102,5 @@ export const locationAtom = atomWithLocation({ getLocation: getAndCanonicalizeLo
 export const currentPathAtom = focusAtom(locationAtom, optic => optic.prop("path"));
 export const currentArchiveAtom = focusAtom(locationAtom, optic => optic.prop("archive"));
 export const selectedImageNameAtom = focusAtom(locationAtom, optic => optic.prop("image"));
+export const selectedTextNameAtom = focusAtom(locationAtom, optic => optic.prop("text"));
 export const globAtom = focusAtom(locationAtom, optic => optic.prop("glob"));

--- a/frontend/finder/states/text.ts
+++ b/frontend/finder/states/text.ts
@@ -1,0 +1,30 @@
+import { atom } from "jotai";
+import { basename } from "path-browserify";
+import {
+  currentPathAtom,
+  selectedImageNameAtom,
+  selectedTextNameAtom,
+} from "./location.ts";
+
+export const isTextModalOpenAtom = atom(
+  (get) => get(selectedTextNameAtom) !== "",
+  (_get, set, open: boolean) => {
+    if (!open) {
+      set(selectedTextNameAtom, "");
+    }
+  }
+);
+
+export const selectedTextPathAtom = atom((get) => {
+  const path = get(currentPathAtom);
+  const textName = get(selectedTextNameAtom);
+  if (path) {
+    return textName ? `${path}/${textName}` : "";
+  }
+  return textName ?? "";
+});
+
+export const onTextModalOpenAtom = atom(null, (_get, set, path: string) => {
+  set(selectedImageNameAtom, "");
+  set(selectedTextNameAtom, basename(path));
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@mandel59/imgserver",
   "version": "0.0.1",
+  "packageManager": "bun@1.3.12",
   "module": "index.ts",
   "type": "module",
   "license": "MIT",
@@ -11,9 +12,12 @@
     "dev": "bun run --hot index.ts --dir images --logging \"/.be/api/*\" --development",
     "start": "bun run index.ts --dir images",
     "compile": "bun build --compile --outfile=imgserver index.ts",
-    "test": "bun test"
+    "test": "bun test",
+    "test:e2e": "bunx playwright test",
+    "playwright:install": "bunx playwright install chromium"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@types/adm-zip": "^0.5.7",
     "@types/bun": "^1.3.10",
     "@types/hammerjs": "^2.0.46",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,5 +28,14 @@
     "paths": {
       "@/common/*": ["./common/*"]
     }
-  }
+  },
+  "include": [
+    "backend/**/*",
+    "common/**/*",
+    "frontend/**/*",
+    "*.ts",
+    "*.tsx",
+    "global.d.ts"
+  ],
+  "exclude": ["node_modules", "workspaces", "test-results"]
 }


### PR DESCRIPTION
## Summary
- add backend text-file API for supported UTF-8 text extensions with a 1 MiB limit
- mark text files in listings and open them in a browser modal with URL state
- standardize Bun/Playwright tooling and keep TypeScript checks out of workspaces

## Verification
- bunx tsc --noEmit
- bun test backend/app.test.ts
- bun run test:e2e tmp-text-preview.spec.ts --reporter=line (temporary local fixture/spec, removed before commit)

Closes #20