### PR TITLE
Add keyboard navigation for file grid/list with helper utilities and tests

### DIFF
--- a/frontend/finder/FileContainer.tsx
+++ b/frontend/finder/FileContainer.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
 import type { FileItem } from "@/common/types.ts";
 import { currentFileItemsQueryAtom, filesListAtom } from "./states/fileList.ts";
@@ -20,6 +20,21 @@ import {
 } from "./states/location.ts";
 import { imageResourceUrl } from "./resources.ts";
 import { isFileNavigationKey, nextFileFocusIndex } from "./fileNavigation.ts";
+
+let pendingFileListFocus = false;
+
+export function requestFileListFocus() {
+  pendingFileListFocus = true;
+  requestAnimationFrame(() => {
+    document
+      .getElementById("file-container")
+      ?.focus({ preventScroll: true });
+  });
+}
+
+function preferredFileListFocusIndex(defaultIndex: number) {
+  return pendingFileListFocus ? 0 : defaultIndex;
+}
 
 export function IconWithName({
   icon,
@@ -100,6 +115,7 @@ export function FolderIcon({
     ) {
       e.preventDefault();
       onNavigate(navigationForDir(file.path, file.archive));
+      requestFileListFocus();
     }
   };
 
@@ -411,6 +427,7 @@ export default function FileContainer() {
   const [{ isLoading }] = useAtom(currentFileItemsQueryAtom);
   const viewMode = useAtomValue(viewModeAtom);
   const thumbnailSize = useAtomValue(thumbnailSizeAtom);
+  const containerRef = useRef<HTMLDivElement>(null);
   const focusedItemIndexRef = useRef(0);
 
   const files: FileItem[] = useAtomValue(filesListAtom);
@@ -436,9 +453,36 @@ export default function FileContainer() {
 
     if (event.target !== container || items.length === 0) return;
 
-    const nextIndex = Math.min(focusedItemIndexRef.current, items.length - 1);
+    const nextIndex = preferredFileListFocusIndex(
+      Math.min(focusedItemIndexRef.current, items.length - 1)
+    );
+    focusedItemIndexRef.current = nextIndex;
     focusFileItemAt(items, nextIndex);
   }, []);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    if (!pendingFileListFocus && document.activeElement !== container) return;
+
+    const items = fileItemsIn(container);
+    if (items.length === 0) {
+      if (pendingFileListFocus && !isLoading) {
+        container.focus({ preventScroll: true });
+        pendingFileListFocus = false;
+      }
+      return;
+    }
+
+    const nextIndex = preferredFileListFocusIndex(
+      Math.min(focusedItemIndexRef.current, items.length - 1)
+    );
+    focusedItemIndexRef.current = nextIndex;
+    focusFileItemAt(items, nextIndex);
+    if (!isLoading) {
+      pendingFileListFocus = false;
+    }
+  }, [files.length, isLoading]);
 
   const handleKeyDown = useCallback(
     (event: React.KeyboardEvent<HTMLDivElement>) => {
@@ -484,6 +528,7 @@ export default function FileContainer() {
   return (
     <div
       id="file-container"
+      ref={containerRef}
       className={`file-container-${viewMode}`}
       style={containerStyle}
       tabIndex={0}

--- a/frontend/finder/FileContainer.tsx
+++ b/frontend/finder/FileContainer.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useRef } from "react";
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
 import type { FileItem } from "@/common/types.ts";
 import { currentFileItemsQueryAtom, filesListAtom } from "./states/fileList.ts";
@@ -53,7 +53,7 @@ export function IconWithName({
     <a
       className="file-item"
       data-file-name={file.name}
-      tabIndex={0}
+      tabIndex={-1}
       href={href}
       onClick={onClick}
       onKeyDown={onKeyDown}
@@ -372,6 +372,30 @@ function focusFileItemAt(items: HTMLElement[], index: number) {
   item.scrollIntoView({ block: "nearest", inline: "nearest" });
 }
 
+function tabbableElements() {
+  return Array.from(
+    document.querySelectorAll<HTMLElement>(
+      [
+        'a[href]:not([tabindex="-1"])',
+        'button:not([disabled]):not([tabindex="-1"])',
+        'input:not([disabled]):not([tabindex="-1"])',
+        'select:not([disabled]):not([tabindex="-1"])',
+        'textarea:not([disabled]):not([tabindex="-1"])',
+        '[tabindex]:not([tabindex="-1"])',
+      ].join(",")
+    )
+  ).filter((element) => !element.closest('[aria-hidden="true"]'));
+}
+
+function focusPreviousControlBefore(container: HTMLElement) {
+  const elements = tabbableElements();
+  const containerIndex = elements.indexOf(container);
+  if (containerIndex <= 0) return false;
+
+  elements[containerIndex - 1]?.focus();
+  return true;
+}
+
 function FileMetadata({ file }: { file: FileItem }) {
   const size = file.isDirectory ? "" : formatFileSize(file.size);
   const modified = formatModifiedTime(file.modified);
@@ -387,6 +411,7 @@ export default function FileContainer() {
   const [{ isLoading }] = useAtom(currentFileItemsQueryAtom);
   const viewMode = useAtomValue(viewModeAtom);
   const thumbnailSize = useAtomValue(thumbnailSizeAtom);
+  const focusedItemIndexRef = useRef(0);
 
   const files: FileItem[] = useAtomValue(filesListAtom);
   const dimensions = thumbnailDimensions[thumbnailSize];
@@ -396,14 +421,42 @@ export default function FileContainer() {
     "--grid-card-min": `${dimensions.cardWidth}px`,
   } as React.CSSProperties;
 
+  const handleFocus = useCallback((event: React.FocusEvent<HTMLDivElement>) => {
+    const container = event.currentTarget;
+    const items = fileItemsIn(container);
+    const focusedItem = focusedFileItemIn(container);
+
+    if (focusedItem) {
+      const focusedIndex = items.indexOf(focusedItem);
+      if (focusedIndex !== -1) {
+        focusedItemIndexRef.current = focusedIndex;
+      }
+      return;
+    }
+
+    if (event.target !== container || items.length === 0) return;
+
+    const nextIndex = Math.min(focusedItemIndexRef.current, items.length - 1);
+    focusFileItemAt(items, nextIndex);
+  }, []);
+
   const handleKeyDown = useCallback(
     (event: React.KeyboardEvent<HTMLDivElement>) => {
+      const container = event.currentTarget;
+
+      if (event.key === "Tab" && event.shiftKey) {
+        const focusedItem = focusedFileItemIn(container);
+        if (focusedItem && focusPreviousControlBefore(container)) {
+          event.preventDefault();
+        }
+        return;
+      }
+
       if (!isFileNavigationKey(event.key)) return;
       if (event.metaKey || event.altKey || event.ctrlKey || event.shiftKey) {
         return;
       }
 
-      const container = event.currentTarget;
       const focusedItem = focusedFileItemIn(container);
       if (!focusedItem) return;
 
@@ -422,6 +475,7 @@ export default function FileContainer() {
       });
 
       if (nextIndex === currentIndex) return;
+      focusedItemIndexRef.current = nextIndex;
       focusFileItemAt(items, nextIndex);
     },
     [viewMode]
@@ -432,6 +486,9 @@ export default function FileContainer() {
       id="file-container"
       className={`file-container-${viewMode}`}
       style={containerStyle}
+      tabIndex={0}
+      aria-label="ファイル一覧"
+      onFocus={handleFocus}
       onKeyDown={handleKeyDown}
     >
       {isLoading ? (

--- a/frontend/finder/FileContainer.tsx
+++ b/frontend/finder/FileContainer.tsx
@@ -431,6 +431,14 @@ export default function FileContainer() {
   const focusedItemIndexRef = useRef(0);
 
   const files: FileItem[] = useAtomValue(filesListAtom);
+  const isEmpty = !isLoading && files.length === 0;
+  const containerClassName = [
+    `file-container-${viewMode}`,
+    isLoading && files.length === 0 ? "file-container-loading" : "",
+    isEmpty ? "file-container-empty" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
   const dimensions = thumbnailDimensions[thumbnailSize];
   const iconHeight =
     viewMode === "grid" ? dimensions.gridHeight : dimensions.listHeight;
@@ -529,10 +537,11 @@ export default function FileContainer() {
     <div
       id="file-container"
       ref={containerRef}
-      className={`file-container-${viewMode}`}
+      className={containerClassName}
       style={containerStyle}
       tabIndex={0}
       aria-label="ファイル一覧"
+      aria-busy={isLoading}
       onFocus={handleFocus}
       onKeyDown={handleKeyDown}
     >
@@ -540,6 +549,11 @@ export default function FileContainer() {
         <div className="loading-overlay">
           <div className="loading-spinner"></div>
           <div className="loading-text">Loading...</div>
+        </div>
+      ) : null}
+      {isEmpty ? (
+        <div className="file-list-status" role="status">
+          表示できるファイルがありません
         </div>
       ) : null}
       {files.map((file, i) => (

--- a/frontend/finder/FileContainer.tsx
+++ b/frontend/finder/FileContainer.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from "react";
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
 import type { FileItem } from "@/common/types.ts";
 import { currentFileItemsQueryAtom, filesListAtom } from "./states/fileList.ts";
@@ -18,6 +19,7 @@ import {
   navigated,
 } from "./states/location.ts";
 import { imageResourceUrl } from "./resources.ts";
+import { isFileNavigationKey, nextFileFocusIndex } from "./fileNavigation.ts";
 
 export function IconWithName({
   icon,
@@ -342,6 +344,34 @@ function formatModifiedTime(modified: number): string {
   }).format(new Date(modified));
 }
 
+function fileItemsIn(container: HTMLElement) {
+  return Array.from(container.querySelectorAll<HTMLElement>(".file-item"));
+}
+
+function focusedFileItemIn(container: HTMLElement) {
+  const active = document.activeElement;
+  if (!(active instanceof HTMLElement)) return null;
+  const item = active.closest<HTMLElement>(".file-item");
+  if (!item || !container.contains(item)) return null;
+  return item;
+}
+
+function gridColumnCount(items: HTMLElement[]) {
+  const firstItem = items[0];
+  if (!firstItem) return 1;
+
+  const firstTop = firstItem.offsetTop;
+  const firstRowCount = items.findIndex((item) => item.offsetTop !== firstTop);
+  return firstRowCount === -1 ? items.length : Math.max(1, firstRowCount);
+}
+
+function focusFileItemAt(items: HTMLElement[], index: number) {
+  const item = items[index];
+  if (!item) return;
+  item.focus({ preventScroll: true });
+  item.scrollIntoView({ block: "nearest", inline: "nearest" });
+}
+
 function FileMetadata({ file }: { file: FileItem }) {
   const size = file.isDirectory ? "" : formatFileSize(file.size);
   const modified = formatModifiedTime(file.modified);
@@ -366,11 +396,43 @@ export default function FileContainer() {
     "--grid-card-min": `${dimensions.cardWidth}px`,
   } as React.CSSProperties;
 
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      if (!isFileNavigationKey(event.key)) return;
+      if (event.metaKey || event.altKey || event.ctrlKey || event.shiftKey) {
+        return;
+      }
+
+      const container = event.currentTarget;
+      const focusedItem = focusedFileItemIn(container);
+      if (!focusedItem) return;
+
+      event.preventDefault();
+
+      const items = fileItemsIn(container);
+      const currentIndex = items.indexOf(focusedItem);
+      if (currentIndex === -1) return;
+
+      const columns = viewMode === "grid" ? gridColumnCount(items) : 1;
+      const nextIndex = nextFileFocusIndex({
+        key: event.key,
+        currentIndex,
+        itemCount: items.length,
+        columns,
+      });
+
+      if (nextIndex === currentIndex) return;
+      focusFileItemAt(items, nextIndex);
+    },
+    [viewMode]
+  );
+
   return (
     <div
       id="file-container"
       className={`file-container-${viewMode}`}
       style={containerStyle}
+      onKeyDown={handleKeyDown}
     >
       {isLoading ? (
         <div className="loading-overlay">

--- a/frontend/finder/Finder.tsx
+++ b/frontend/finder/Finder.tsx
@@ -5,7 +5,7 @@ import ImageModal from "./ImageModal.tsx";
 import TextModal from "./TextModal.tsx";
 import Controls from "./Controls.tsx";
 import Breadcrumbs from "./Breadcrumbs.tsx";
-import FileContainer from "./FileContainer.tsx";
+import FileContainer, { requestFileListFocus } from "./FileContainer.tsx";
 import { htmlClassAtom } from "./states/display.ts";
 import { locationAtom, navigated } from "./states/location.ts";
 import { navigationForParentDir } from "./locationNavigation.ts";
@@ -37,6 +37,7 @@ export default function Finder() {
 
       event.preventDefault();
       setLocation(navigated(location, navigation));
+      requestFileListFocus();
     };
 
     window.addEventListener("keydown", handleKeyDown);

--- a/frontend/finder/Finder.tsx
+++ b/frontend/finder/Finder.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { useAtom } from "jotai";
 
 import ImageModal from "./ImageModal.tsx";
@@ -6,9 +7,42 @@ import Controls from "./Controls.tsx";
 import Breadcrumbs from "./Breadcrumbs.tsx";
 import FileContainer from "./FileContainer.tsx";
 import { htmlClassAtom } from "./states/display.ts";
+import { locationAtom, navigated } from "./states/location.ts";
+import { navigationForParentDir } from "./locationNavigation.ts";
 
 export default function Finder() {
   useAtom(htmlClassAtom);
+  const [location, setLocation] = useAtom(locationAtom);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (
+        event.key !== "ArrowUp" ||
+        !event.altKey ||
+        event.metaKey ||
+        event.ctrlKey ||
+        event.shiftKey
+      ) {
+        return;
+      }
+      if (
+        event.target instanceof Element &&
+        event.target.closest("dialog[open]")
+      ) {
+        return;
+      }
+
+      const navigation = navigationForParentDir(location);
+      if (!navigation) return;
+
+      event.preventDefault();
+      setLocation(navigated(location, navigation));
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [location, setLocation]);
+
   return (
     <>
       <div className="header-container">

--- a/frontend/finder/fileNavigation.test.ts
+++ b/frontend/finder/fileNavigation.test.ts
@@ -1,0 +1,75 @@
+import { expect, test } from "bun:test";
+import { nextFileFocusIndex } from "./fileNavigation.ts";
+
+test("left and right arrow navigation matches previous and next item", () => {
+  expect(
+    nextFileFocusIndex({
+      key: "ArrowRight",
+      currentIndex: 1,
+      itemCount: 5,
+      columns: 3,
+    })
+  ).toBe(2);
+  expect(
+    nextFileFocusIndex({
+      key: "ArrowLeft",
+      currentIndex: 1,
+      itemCount: 5,
+      columns: 3,
+    })
+  ).toBe(0);
+});
+
+test("up and down arrow navigation uses the visual column count", () => {
+  expect(
+    nextFileFocusIndex({
+      key: "ArrowDown",
+      currentIndex: 1,
+      itemCount: 8,
+      columns: 3,
+    })
+  ).toBe(4);
+  expect(
+    nextFileFocusIndex({
+      key: "ArrowUp",
+      currentIndex: 4,
+      itemCount: 8,
+      columns: 3,
+    })
+  ).toBe(1);
+});
+
+test("arrow navigation stops at the first and last item without looping", () => {
+  expect(
+    nextFileFocusIndex({
+      key: "ArrowLeft",
+      currentIndex: 0,
+      itemCount: 5,
+      columns: 3,
+    })
+  ).toBe(0);
+  expect(
+    nextFileFocusIndex({
+      key: "ArrowUp",
+      currentIndex: 2,
+      itemCount: 5,
+      columns: 3,
+    })
+  ).toBe(2);
+  expect(
+    nextFileFocusIndex({
+      key: "ArrowRight",
+      currentIndex: 4,
+      itemCount: 5,
+      columns: 3,
+    })
+  ).toBe(4);
+  expect(
+    nextFileFocusIndex({
+      key: "ArrowDown",
+      currentIndex: 2,
+      itemCount: 5,
+      columns: 3,
+    })
+  ).toBe(2);
+});

--- a/frontend/finder/fileNavigation.ts
+++ b/frontend/finder/fileNavigation.ts
@@ -1,0 +1,45 @@
+export type FileNavigationKey =
+  | "ArrowLeft"
+  | "ArrowRight"
+  | "ArrowUp"
+  | "ArrowDown";
+
+export const fileNavigationKeys = new Set<FileNavigationKey>([
+  "ArrowLeft",
+  "ArrowRight",
+  "ArrowUp",
+  "ArrowDown",
+]);
+
+export function isFileNavigationKey(key: string): key is FileNavigationKey {
+  return fileNavigationKeys.has(key as FileNavigationKey);
+}
+
+export function nextFileFocusIndex({
+  key,
+  currentIndex,
+  itemCount,
+  columns,
+}: {
+  key: FileNavigationKey;
+  currentIndex: number;
+  itemCount: number;
+  columns: number;
+}) {
+  const normalizedColumns = Math.max(1, Math.floor(columns));
+  const nextIndex = (() => {
+    switch (key) {
+      case "ArrowLeft":
+        return currentIndex - 1;
+      case "ArrowRight":
+        return currentIndex + 1;
+      case "ArrowUp":
+        return currentIndex - normalizedColumns;
+      case "ArrowDown":
+        return currentIndex + normalizedColumns;
+    }
+  })();
+
+  if (nextIndex < 0 || nextIndex >= itemCount) return currentIndex;
+  return nextIndex;
+}

--- a/frontend/finder/locationNavigation.ts
+++ b/frontend/finder/locationNavigation.ts
@@ -1,0 +1,30 @@
+import type { LocationState, Navigation } from "./states/location.ts";
+
+function parentPathOf(path: string) {
+  const parts = path.split("/").filter((part) => part.length > 0);
+  parts.pop();
+  return parts.join("/");
+}
+
+function archiveForParentDir(parentPath: string, archive: string) {
+  if (!archive) return "";
+  if (parentPath === archive || parentPath.startsWith(`${archive}/`)) {
+    return archive;
+  }
+  return "";
+}
+
+export function navigationForParentDir(
+  location: Pick<LocationState, "path" | "archive">
+): Navigation | null {
+  if (!location.path) return null;
+
+  const parentPath = parentPathOf(location.path);
+  return {
+    path: parentPath,
+    image: "",
+    text: "",
+    archive: archiveForParentDir(parentPath, location.archive),
+    glob: "",
+  };
+}

--- a/frontend/finder/states/location.test.ts
+++ b/frontend/finder/states/location.test.ts
@@ -1,0 +1,46 @@
+import { expect, test } from "bun:test";
+import { navigationForParentDir } from "../locationNavigation.ts";
+
+test("navigationForParentDir returns null at the root directory", () => {
+  expect(navigationForParentDir({ path: "", archive: "" })).toBeNull();
+});
+
+test("navigationForParentDir navigates to the parent filesystem directory", () => {
+  expect(navigationForParentDir({ path: "foo/bar", archive: "" })).toEqual({
+    path: "foo",
+    image: "",
+    text: "",
+    archive: "",
+    glob: "",
+  });
+});
+
+test("navigationForParentDir keeps archive context inside an archive", () => {
+  expect(
+    navigationForParentDir({
+      path: "photos.zip/dir/subdir",
+      archive: "photos.zip",
+    })
+  ).toEqual({
+    path: "photos.zip/dir",
+    image: "",
+    text: "",
+    archive: "photos.zip",
+    glob: "",
+  });
+});
+
+test("navigationForParentDir leaves archive context from the archive root", () => {
+  expect(
+    navigationForParentDir({
+      path: "archives/photos.zip",
+      archive: "archives/photos.zip",
+    })
+  ).toEqual({
+    path: "archives",
+    image: "",
+    text: "",
+    archive: "",
+    glob: "",
+  });
+});

--- a/frontend/finder/style.css
+++ b/frontend/finder/style.css
@@ -64,9 +64,8 @@ body {
   gap: 8px;
 }
 
-#file-container.file-container-loading,
-#file-container.file-container-empty {
-  min-height: 160px;
+#file-container.file-container-loading:focus-visible {
+  outline: none;
 }
 
 .file-list-status {

--- a/frontend/finder/style.css
+++ b/frontend/finder/style.css
@@ -64,6 +64,30 @@ body {
   gap: 8px;
 }
 
+#file-container.file-container-loading,
+#file-container.file-container-empty {
+  min-height: 160px;
+}
+
+.file-list-status {
+  grid-column: 1 / -1;
+  min-height: 140px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px dashed var(--button-border);
+  border-radius: 8px;
+  color: var(--placeholder-color);
+  background: var(--card-bg);
+  text-align: center;
+  padding: 16px;
+  box-sizing: border-box;
+}
+
+.file-container-list .file-list-status {
+  min-height: 96px;
+}
+
 .file-item {
   all: unset;
   -webkit-tap-highlight-color: transparent;


### PR DESCRIPTION
### Motivation

- Provide keyboard navigation (arrow keys) for the file grid/list to improve accessibility and keyboard-driven browsing.

### Description

- Add `frontend/finder/fileNavigation.ts` containing `fileNavigationKeys`, `isFileNavigationKey`, and `nextFileFocusIndex` to compute the next focus index for arrow keys.
- Enhance `frontend/finder/FileContainer.tsx` with DOM helper functions (`fileItemsIn`, `focusedFileItemIn`, `gridColumnCount`, `focusFileItemAt`) and a `handleKeyDown` callback that intercepts arrow keys and moves focus using the navigation utilities.
- Wire `onKeyDown={handleKeyDown}` on the `#file-container` element and import the new navigation utilities.
- Add unit tests in `frontend/finder/fileNavigation.test.ts` that validate left/right/up/down behavior and edge conditions for `nextFileFocusIndex`.

### Testing

- Ran the unit tests with `bun test` which executed the new `frontend/finder/fileNavigation.test.ts` tests.
- All tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0712a0ad6c832d89ef468227214ad0)