### PR TITLE
Keep Alt+Up focus on exited folder

### DIFF
--- a/frontend/finder/FileContainer.tsx
+++ b/frontend/finder/FileContainer.tsx
@@ -22,9 +22,11 @@ import { imageResourceUrl } from "./resources.ts";
 import { isFileNavigationKey, nextFileFocusIndex } from "./fileNavigation.ts";
 
 let pendingFileListFocus = false;
+let pendingFileListFocusName: string | null = null;
 
-export function requestFileListFocus() {
+export function requestFileListFocus(fileName?: string) {
   pendingFileListFocus = true;
+  pendingFileListFocusName = fileName ?? null;
   requestAnimationFrame(() => {
     document
       .getElementById("file-container")
@@ -32,8 +34,14 @@ export function requestFileListFocus() {
   });
 }
 
-function preferredFileListFocusIndex(defaultIndex: number) {
-  return pendingFileListFocus ? 0 : defaultIndex;
+function preferredFileListFocusIndex(items: HTMLElement[], defaultIndex: number) {
+  if (!pendingFileListFocus) return defaultIndex;
+  if (!pendingFileListFocusName) return 0;
+
+  const targetIndex = items.findIndex(
+    (item) => item.dataset.fileName === pendingFileListFocusName
+  );
+  return targetIndex === -1 ? 0 : targetIndex;
 }
 
 export function IconWithName({
@@ -462,6 +470,7 @@ export default function FileContainer() {
     if (event.target !== container || items.length === 0) return;
 
     const nextIndex = preferredFileListFocusIndex(
+      items,
       Math.min(focusedItemIndexRef.current, items.length - 1)
     );
     focusedItemIndexRef.current = nextIndex;
@@ -483,12 +492,14 @@ export default function FileContainer() {
     }
 
     const nextIndex = preferredFileListFocusIndex(
+      items,
       Math.min(focusedItemIndexRef.current, items.length - 1)
     );
     focusedItemIndexRef.current = nextIndex;
     focusFileItemAt(items, nextIndex);
     if (!isLoading) {
       pendingFileListFocus = false;
+      pendingFileListFocusName = null;
     }
   }, [files.length, isLoading]);
 

--- a/frontend/finder/Finder.tsx
+++ b/frontend/finder/Finder.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from "react";
+import { basename } from "path-browserify";
 import { useAtom } from "jotai";
 
 import ImageModal from "./ImageModal.tsx";
@@ -37,7 +38,7 @@ export default function Finder() {
 
       event.preventDefault();
       setLocation(navigated(location, navigation));
-      requestFileListFocus();
+      requestFileListFocus(basename(location.path));
     };
 
     window.addEventListener("keydown", handleKeyDown);


### PR DESCRIPTION
### Motivation

- Improve keyboard navigation so that pressing `Alt+ArrowUp` to go to the parent directory restores keyboard focus to the folder that was just exited when that folder exists in the parent listing.
- If the exited folder is not present in the parent listing, preserve the existing behavior of focusing the first item.

### Description

- Pass the previous directory name from `Finder` into the focus helper by calling `requestFileListFocus(basename(location.path))` in `frontend/finder/Finder.tsx`.
- Extend `requestFileListFocus` in `frontend/finder/FileContainer.tsx` to accept an optional `fileName` and store it in a new `pendingFileListFocusName` variable.
- Add `preferredFileListFocusIndex(items, defaultIndex)` that resolves the preferred index by looking up `data-file-name` against `pendingFileListFocusName` and falls back to index `0` when not found.
- Use the new preferred-index logic from `handleFocus` and the `useEffect` that applies pending focus, and clear `pendingFileListFocusName` once focus is applied.

### Testing

- Ran `bun test frontend/finder/states/location.test.ts frontend/finder/fileNavigation.test.ts`, all tests passed (7 tests, 0 failures).
- Attempted to run `jj diff --git` as preferred by repository guidelines but the `jj` command was not available in the environment, so standard `git` was used for the local commit operations instead.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14b152ce74832d96776292800707c1)