### PR TITLE
Prevent focused file from hiding behind sticky header

### DIFF
--- a/frontend/finder/FileContainer.tsx
+++ b/frontend/finder/FileContainer.tsx
@@ -394,6 +394,15 @@ function focusFileItemAt(items: HTMLElement[], index: number) {
   if (!item) return;
   item.focus({ preventScroll: true });
   item.scrollIntoView({ block: "nearest", inline: "nearest" });
+  const headerBottom =
+    document.querySelector<HTMLElement>(".header-container")
+      ?.getBoundingClientRect().bottom ?? 0;
+  const topPadding = 8;
+  const minVisibleTop = headerBottom + topPadding;
+  const rect = item.getBoundingClientRect();
+  if (rect.top < minVisibleTop) {
+    window.scrollBy({ top: rect.top - minVisibleTop });
+  }
 }
 
 function tabbableElements() {


### PR DESCRIPTION
### Motivation
- When navigating the file list with the keyboard, focused items could end up hidden under the sticky top toolbar, causing a poor UX when moving up with the ArrowUp key.  

### Description
- Adjust `focusFileItemAt` in `frontend/finder/FileContainer.tsx` to compute the header bottom and, after `scrollIntoView`, apply a corrective `window.scrollBy` when the focused item's top would be above the header; this keeps the focused item visible below the toolbar.  

### Testing
- Ran `npm test -- --runInBand` and all frontend/backend tests passed (39 tests, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14b61d7124832d947d2b9a3aeaba1c)